### PR TITLE
Don't show zip build if doesn't exist

### DIFF
--- a/src/pages/download.page.tsx
+++ b/src/pages/download.page.tsx
@@ -122,15 +122,17 @@ function Page(pageProps: {
                             </HStack>
                         </VStack>
                     </Button>
-                    <Text color="white">
-                        Or download the{' '}
-                        <Link
-                            color="blue.300"
-                            href={zipBuild?.browser_download_url}
-                        >
-                            portable version (zip)
-                        </Link>
-                    </Text>
+                    {zipBuild != null && (
+                        <Text color="white">
+                            Or download the{' '}
+                            <Link
+                                color="blue.300"
+                                href={zipBuild?.browser_download_url}
+                            >
+                                portable version (zip)
+                            </Link>
+                        </Text>
+                    )}
                 </VStack>
                 <Box
                     color="white"


### PR DESCRIPTION
In preparation for https://github.com/chaiNNer-org/chaiNNer/pull/2119, we need to make sure we don't always show a zip build as being available.